### PR TITLE
Change php.ini scan directory to DDEV default

### DIFF
--- a/frankenphp/.env
+++ b/frankenphp/.env
@@ -1,7 +1,7 @@
 #ddev-generated
 
 # Details: https://www.php.net/manual/en/configuration.file.php
-PHP_INI_SCAN_DIR=./
+PHP_INI_SCAN_DIR=./.ddev/php/
 
 # Details: https://mercure.rocks/docs/hub/config
 MERCURE_PUBLISHER_JWT_KEY=!ChangeMe!


### PR DESCRIPTION
The value of the environment variable PHP_INI_SCAN_DIR is changed to ./.ddev/php/, which is the default directory for a custom php.ini in DDEV.

https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#custom-php-configuration-phpini

![image](https://github.com/user-attachments/assets/fa0b62de-f581-4c79-8287-b5b934ad113c)
