### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ The WHY!
 
 ## Installation
 
-```bash
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ochorocho/ddev-frankenphp && ddev restart
+```
+
+For earlier versions of DDEV run
+
+```sh
 ddev get ochorocho/ddev-frankenphp && ddev restart
 ```
 
@@ -23,4 +31,3 @@ ddev get ochorocho/ddev-frankenphp && ddev restart
 This way all domains configured by ddev will be used by frankenphp as well.
 
 `MERCURE_PUBLIC_URL` will use the `DDEV_PRIMARY_URL` (`$DDEV_PRIMARY_URL/.well-known/mercure`)
-


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.